### PR TITLE
Add Apple 1 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-TARGETS = sim6502 apple2 apple2_lc atari ac6502 vc83_serial
+TARGETS = sim6502 apple1 apple2 apple2_lc atari ac6502 vc83_serial
 TEST_TARGET = sim6502
 
 TESTS = $(notdir $(basename $(wildcard tests/*_test.c)))
@@ -42,6 +42,16 @@ build/basic_sim6502.o: targets/sim6502/basic_sim6502.s src/basic.s $(GENERATED_A
 build/basic_sim6502: build/basic_sim6502.o
 	@mkdir -p $(@D)
 	cl65 -t sim6502 -C targets/sim6502/sim6502.cfg $(LDFLAGS) -o $@ $<
+	$(PRINT_SIZE)
+
+# Goal: basic_apple1
+build/basic_apple1.o: targets/apple1/basic_apple1.s src/basic.s $(GENERATED_ASM_SOURCES)
+	@mkdir -p $(@D)
+	cl65 -t none -c $(ASMFLAGS) --asm-include-dir targets/apple1 -o $@ $<
+
+build/basic_apple1: build/basic_apple1.o
+	@mkdir -p $(@D)
+	cl65 -t none -C targets/apple1/apple1.cfg $(LDFLAGS) -o $@ $<
 	$(PRINT_SIZE)
 
 # Goal: basic_apple2

--- a/README.md
+++ b/README.md
@@ -61,6 +61,33 @@ To run on real hardware, you obviously need to put `basic.dsk` on a physical dis
 a [Floppy Emu](https://www.bigmessowires.com/floppy-emu/). If you have an actual Apple II then you presumably understand
 how to do this. I've only tested on my Apple II+, so if it doesn't work on your e/c/gs, let me know.
 
+### Apple 1
+
+The `basic_apple1` binary targets the original Apple 1 and compatible hardware including the
+[Replica-1](https://www.corshamtech.com/product/replica-1-plus/), [APL1](https://github.com/acwright/APL1),
+and most Apple 1 emulators. All of these use the original Apple 1 PIA I/O at `$D010–$D013`. The binary
+loads at `$4000`.
+
+1.  Build the binary:
+    ```bash
+    make build/basic_apple1
+    ```
+
+2.  Convert the raw binary to WozMon-formatted text using [bin2woz](https://github.com/acwright/bin2woz):
+    ```bash
+    bin2woz -a 0x4000 build/basic_apple1 > build/basic_apple1.woz
+    ```
+    Each line of the output contains a 4-digit hex address followed by up to 16 bytes, ready
+    to be pasted into WozMon or sent via the APL1 Terminal's Send Program panel.
+
+3.  Load the program into your Apple 1 (or emulator) using WozMon by pasting or typing the
+    contents of `basic_apple1.woz`.
+
+4.  Run it:
+    ```
+    4000R
+    ```
+
 ## Memory Map
 
 The interpreter manages memory using several zero-page pointers:

--- a/targets/apple1/apple1.cfg
+++ b/targets/apple1/apple1.cfg
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2022-2026 Willis Blackburn
+#
+# SPDX-License-Identifier: MIT
+#
+# Linker configuration for VC83 BASIC targeting the Apple 1, Replica-1,
+# APL1, and compatible emulators.
+#
+# Memory layout:
+#   $0000-$002D  WozMon zero-page variables (avoid)
+#   $002E-$007F  WozMon / system use (avoid)
+#   $0080-$00FF  VC83 zero page
+#   $0100-$01FF  6502 hardware stack
+#   $0200-$02FF  WozMon input buffer / scratch (avoid)
+#   $0300-$04FF  VC83 I/O buffers (not in binary)
+#   $0500-$3FFF  Free RAM
+#   $4000-$7FFF  VC83 BASIC code + BSS + user program (this binary loads here)
+#   $D010-$D013  Apple 1 PIA (keyboard and display I/O)
+#   $FF00-$FFFF  WozMon ROM
+#
+# Load the binary with WozMon and run with: 4000R
+
+SYMBOLS {
+    __BUFFERS_SIZE__: type = weak, value = $0200;
+    __HIMEM__:        type = weak, value = $8000;
+}
+MEMORY {
+    ZEROPAGE:  file = "", start = $0080, size = $0080;
+    BUFFERS:   file = "", start = $0300, size = $0200;
+    MAIN:      file = %O, start = $4000, size = $8000 - $4000, define = yes;
+}
+SEGMENTS {
+    ZEROPAGE:  load = ZEROPAGE, type = zp;
+    BUFFERS:   load = BUFFERS,  type = bss;
+    STARTUP:   load = MAIN,     type = ro;
+    CODE:      load = MAIN,     type = ro;
+    VEC:       load = MAIN,     type = ro,  define = yes;
+    XVEC:      load = MAIN,     type = ro,  define = yes;
+    FUNC:      load = MAIN,     type = ro,  define = yes;
+    XFUNC:     load = MAIN,     type = ro,  define = yes;
+    PARSER:    load = MAIN,     type = ro;
+    ONCE:      load = MAIN,     type = ro,  define = yes;
+    BSS:       load = MAIN,     type = bss, define = yes, align = 256;
+}

--- a/targets/apple1/apple1.inc
+++ b/targets/apple1/apple1.inc
@@ -1,0 +1,12 @@
+; SPDX-FileCopyrightText: 2022-2026 Willis Blackburn
+;
+; SPDX-License-Identifier: MIT
+
+; Apple 1 PIA (6820) I/O registers at $D010-$D013.
+; These addresses are used by the original Apple 1, Replica-1, APL1,
+; and most Apple 1 emulators.
+
+KBD     := $D010        ; Keyboard data register (bit 7 set = character available)
+KBDCR   := $D011        ; Keyboard control register (bit 7 = key strobe)
+DSP     := $D012        ; Display data register (write character with bit 7 set)
+DSPCR   := $D013        ; Display control register

--- a/targets/apple1/apple1_extension.s
+++ b/targets/apple1/apple1_extension.s
@@ -1,0 +1,21 @@
+; SPDX-FileCopyrightText: 2022-2026 Willis Blackburn
+;
+; SPDX-License-Identifier: MIT
+
+.segment "PARSER"
+
+ex_statement_name_table:
+        name_table_end
+
+ex_function_name_table:
+        name_table_end
+
+.segment "XVEC"
+
+ex_statement_vectors:
+
+.segment "XFUNC"
+
+ex_function_table:
+
+.code

--- a/targets/apple1/apple1_init.s
+++ b/targets/apple1/apple1_init.s
@@ -1,0 +1,33 @@
+; SPDX-FileCopyrightText: 2022-2026 Willis Blackburn
+;
+; SPDX-License-Identifier: MIT
+
+.segment "BUFFERS"
+
+buffer:         .res BUFFER_SIZE
+line_buffer:    .res BUFFER_SIZE
+
+.segment "ONCE"
+
+initialize_target:
+        ; Initialize expression stack positions (BSS is not zeroed on bare metal)
+        lda     #PRIMARY_STACK_SIZE
+        sta     stack_pos
+        lda     #OP_STACK_SIZE
+        sta     op_stack_pos
+
+        ; RAM ends at $7FFF on Replica-1, APL1, and most Apple 1 replicas
+        mvax    #$8000, himem_ptr
+
+        ; WozMon leaves the cursor on the same line as the "4000R" command,
+        ; so output a newline before the banner to start on a fresh line.
+        jsr     newline
+        jmp     display_startup_banner
+
+.bss
+
+.align 256
+stack:          .res PRIMARY_STACK_SIZE
+op_stack:       .res OP_STACK_SIZE
+
+.code

--- a/targets/apple1/apple1_io.s
+++ b/targets/apple1/apple1_io.s
@@ -1,0 +1,89 @@
+; SPDX-FileCopyrightText: 2022-2026 Willis Blackburn
+;
+; SPDX-License-Identifier: MIT
+
+.code
+
+; Outputs a carriage return (moves to next line on the Apple 1 display).
+
+newline:
+        lda     #$0D                    ; Carriage Return
+        jmp     putch
+
+; Writes bytes to the display.
+; AX = pointer to buffer, Y = length
+
+write:
+        stax    BC
+        tya
+        tax
+        beq     @done
+        ldy     #0
+@next:
+        lda     (BC),y
+        jsr     putch
+        iny
+        dex
+        bne     @next
+@done:
+        rts
+
+; Writes a single character to the Apple 1 display via the 6820 PIA.
+; Waits until the previous character has been consumed (bit 7 of DSP clear),
+; then writes the character with bit 7 set as required by the PIA.
+
+putch:
+@wait:
+        bit     DSP                     ; Test bit 7: set = display busy
+        bmi     @wait                   ; Wait while busy
+        ora     #$80                    ; Set bit 7 (required by Apple 1 PIA)
+        sta     DSP
+        rts
+
+; Reads a line of input from the Apple 1 keyboard via the 6820 PIA.
+; Characters are echoed to the display as they are typed.
+; Backspace (BS/$08) and Delete ($7F) erase the previous character.
+; Returns when CR is entered.  The line is null-terminated in buffer.
+; Returns the line length in A.
+
+readline:
+        ldx     #0
+@loop:
+@wait_rx:
+        bit     KBDCR                   ; Test bit 7: set = new key available
+        bpl     @wait_rx                ; Wait while no key
+        lda     KBD                     ; Read character (keyboard sets bit 7)
+        and     #$7F                    ; Strip bit 7 to get 7-bit ASCII
+        cmp     #$0D                    ; Carriage return — end of line?
+        beq     @cr
+        cmp     #$08                    ; Backspace?
+        beq     @bs
+        cmp     #$7F                    ; Delete?
+        beq     @bs
+        cmp     #$20                    ; Ignore non-printable characters below space
+        bcc     @loop
+        cpx     #MAX_LINE_LENGTH        ; Ignore if buffer is full
+        bcs     @loop
+        sta     buffer,x               ; Store before echoing (putch clobbers A via ora #$80)
+        jsr     putch                   ; Echo the character
+        inx
+        jmp     @loop
+
+@bs:
+        cpx     #0
+        beq     @loop                   ; Nothing to delete at start of line
+        dex
+        lda     #$08                    ; BS — move cursor left
+        jsr     putch
+        lda     #' '                    ; Overwrite previous character with space
+        jsr     putch
+        lda     #$08                    ; Move cursor left again
+        jsr     putch
+        jmp     @loop
+
+@cr:
+        jsr     putch                   ; Echo CR to advance to next line
+        lda     #0
+        sta     buffer,x                ; Null-terminate the line
+        txa                             ; Return length in A
+        rts

--- a/targets/apple1/apple1_startup.s
+++ b/targets/apple1/apple1_startup.s
@@ -1,0 +1,18 @@
+; SPDX-FileCopyrightText: 2022-2026 Willis Blackburn
+;
+; SPDX-License-Identifier: MIT
+
+.export startup
+
+.segment "STARTUP"
+
+startup:
+        cld                             ; Clear decimal flag
+        ldx     #$FF
+        txs                             ; Initialize the stack to $FF
+        jsr     initialize_target
+        jsr     main
+@halt:
+        jmp     @halt                   ; No OS to return to on this platform
+
+.code

--- a/targets/apple1/basic_apple1.s
+++ b/targets/apple1/basic_apple1.s
@@ -1,0 +1,11 @@
+; SPDX-FileCopyrightText: 2022-2026 Willis Blackburn
+;
+; SPDX-License-Identifier: MIT
+
+.include "basic.s"
+.include "main.s"
+.include "apple1.inc"
+.include "apple1_startup.s"
+.include "apple1_init.s"
+.include "apple1_io.s"
+.include "apple1_extension.s"


### PR DESCRIPTION
I've added an Apple 1 target to VC83 and tested it on the Honeycrisp emulator and my "real" APL1 replica hardware. It loads into RAM at $4000. You can try it in the Honeycrisp emulator by simply pasting the Wozmon text after you clear the screen and reset and then entering `4000R` and Enter. Wozmon text can be generated from the binary with my tool `bin2woz`: https://github.com/acwright/bin2woz. Be sure to change the Honeycrisp settings to 32KB of RAM. 

https://landonjsmith.com/projects/honeycrisp.html

<img width="2560" height="1440" alt="Screenshot 2026-07-06 at 3 38 05 PM" src="https://github.com/user-attachments/assets/dd7cbce9-be29-450c-ae08-d29f1c32960b" />
