### PR TITLE
Update ac6502 target for BIOS v1.5, and fix screen clear, BRK, keyboard and RTC bugs

### DIFF
--- a/targets/ac6502/ac6502.inc
+++ b/targets/ac6502/ac6502.inc
@@ -3,12 +3,16 @@
 ; SPDX-License-Identifier: MIT
 ;
 ; ac6502 target include -- symbolic names for BIOS Kernal routines and
-; system variables used by VC83 BASIC.  See 6502-BIOS/BIOS.inc for the
-; full documentation of the Kernal jump table.
-; 
+; system variables used by VC83 BASIC.  Mirrors the Kernal ABI as of
+; BIOS v1.5; see 6502-BIOS/BIOS.inc and the "Cartridge Support" section
+; of its README for the full documentation.
+;
 ; See https://github.com/acwright/6502-BIOS for more info
 
-BAS_LINBUF_SIZE     = 240
+; The machine is a WDC 65C02S.  basic.s and main.s are included before this
+; file and so stay plain 6502; everything after it -- the target's own startup,
+; buffers, I/O and BASIC extensions -- may use the 65C02 additions.
+.setcpu "65C02"
 
 CH_CTRLC            = $03
 CH_BEL              = $07
@@ -20,11 +24,16 @@ CH_SPACE            = $20
 CH_DEL              = $7F
 
 ; --- Zero-page system pointers (BIOS) ---
+READ_PTR            := $00               ; Input ring buffer read cursor
+WRITE_PTR           := $01               ; Input ring buffer write cursor (IRQ owns it)
 STR_PTR             := $02               ; $02-$03 - BIOS string pointer
 
 ; --- BIOS Kernal jump table ($A000-$A0FF) ---
+; Every entry is a stable 3-byte JMP; the addresses do not move between BIOS
+; versions, so this table is safe to list in full even where VC83 does not
+; (yet) call an entry.
 Chrout              := $A000             ; Output character (routed by IO_MODE)
-Chrin               := $A003             ; Non-blocking input char (C=1 if available)
+Chrin               := $A003             ; Input char, ECHOES it (see get_key in ac6502_io.s)
 WriteBuffer         := $A006
 ReadBuffer          := $A009
 BufferSize          := $A00C
@@ -65,8 +74,23 @@ StWaitReady         := $A072
 SysDelay            := $A075
 KernalInit          := $A078             ; Initialize all hardware; caller resets SP, must CLI after
 KernalVersion       := $A07B
+; --- Added in BIOS v1.1: disk banking and addressed storage ---
+FsLoadFileAddr      := $A07E
+FsSaveFileAddr      := $A081
+FsFormatDisk        := $A084
+FsSetDisk           := $A087
+FsGetDisk           := $A08A
+FsPrintDisk         := $A08D
+; --- Added in BIOS v1.1: console output helpers ---
+PrintStr            := $A090
+PrintCRLF           := $A093
+PrintDecU16         := $A096
+; --- Added in BIOS v1.4: raw keyboard-encoder control ---
+KBDisable           := $A099
+KBEnable            := $A09C
 
 ; --- System RAM variables used here ---
+INPUT_BUFFER        := $0200             ; $0200-$02FF - BIOS keyboard/serial ring buffer
 IRQ_PTR             := $0300
 BRK_PTR             := $0302
 NMI_PTR             := $0304
@@ -79,6 +103,7 @@ CHROUT              := Chrout
 CHRIN               := Chrin
 
 ; --- HW_PRESENT bit masks ---
+; Video is bit 7 on purpose: BIT HW_PRESENT tests it in N without disturbing A.
 HW_RAM_L            = %00000001
 HW_RAM_H            = %00000010
 HW_RTC              = %00000100
@@ -88,6 +113,10 @@ HW_GPIO             = %00100000
 HW_SID              = %01000000
 HW_VID              = %10000000
 
-; --- RTC / storage RAM variables used by kernal routines ---
+; --- RTC variables used by kernal routines ---
 RTC_BUF_CENT        := $030B             ; Century register for RTC read/write
+
+; --- Hardware registers touched directly ---
 RAM_BANK_L          := $83FF             ; Write-only bank latch for low RAM card
+SC_CMD              := $9002             ; Serial card (R65C51) command register
+SC_CMD_RX_READY     = $09                ; No parity/echo, RTSB low, RX interrupts on

--- a/targets/ac6502/ac6502_extension.s
+++ b/targets/ac6502/ac6502_extension.s
@@ -9,9 +9,11 @@
 ;
 ; Missing hardware is handled gracefully: statements print "NO DEVICE"
 ; (or silently skip for video/sound commands, matching the BIOS); the
-; hardware-reading functions return 0.
-
-.setcpu "65C02"
+; hardware-reading functions return whatever the BIOS's own BASIC returns
+; for an absent card -- 0 for NVRAM, $FF for JOY (the ports are active low,
+; so 0 would mean every direction and button held at once).
+;
+; The 65C02 instruction set is enabled in ac6502.inc.
 
 ; --- Parser name tables and argument parsers --------------------------------
 
@@ -166,20 +168,6 @@ ex_print_ax:
         jsr     int_to_fp
         jmp     print_number
 
-; Check for Ctrl-C / ESC in the keyboard buffer.  Raise ERR_STOPPED if found.
-ex_break_check:
-        jsr     Chrin                   ; Non-blocking (C=1 if a char is waiting)
-        bcc     @done
-        cmp     #CH_ESC
-        beq     @brk
-        cmp     #CH_CTRLC
-        bne     @done
-@brk:
-        lda     #ERR_STOPPED
-        jmp     on_raise
-@done:
-        rts
-
 ; ---------------------------------------------------------------------------
 ; Video statements: CLS, LOCATE, COLOR
 ; ---------------------------------------------------------------------------
@@ -191,11 +179,23 @@ exec_cls:
 @skip:
         rts
 
+; LOCATE row, col -- 0-23 and 0-39, range-checked as the BIOS's own BASIC does.
+; VideoSetCursor computes row * 40 + col with no limit of its own, so a row
+; past 51 would leave the cursor beyond the 960-byte name table and let the
+; next PRINT scribble over the character set in the pattern table at VRAM $0800.
 exec_locate:
         jsr     evaluate_argument_list
         jsr     pop_int_fp0             ; col
+        cpx     #0
+        bne     @range
+        cmp     #40
+        bcs     @range
         sta     D                       ; D = col
         jsr     pop_int_fp0             ; row
+        cpx     #0
+        bne     @range
+        cmp     #24
+        bcs     @range
         tay                             ; Y = row
         ldx     D                       ; X = col
         bit     HW_PRESENT
@@ -203,6 +203,8 @@ exec_locate:
         jmp     VideoSetCursor
 @skip:
         rts
+@range:
+        raise   ERR_OUT_OF_RANGE
 
 exec_color:
         jsr     evaluate_argument_list
@@ -323,7 +325,7 @@ exec_wait:
         jsr     pop_int_fp0             ; address
         stax    BC                      ; BC = pointer
 @loop:
-        jsr     ex_break_check
+        jsr     check_break             ; WAIT can spin forever -- stay breakable
         ldy     #0
         lda     (BC),y
         and     D
@@ -376,40 +378,51 @@ exec_date:
         jsr     ex_print_2d
         jmp     newline
 
+; Only D and E survive a pop_int_fp0 (pop_fp0 is documented DE SAFE, not BC
+; SAFE), and SETTIME has three values to hold, so the surplus goes on the CPU
+; stack -- the same trick exec_sound uses.
 exec_settime:
         jsr     evaluate_argument_list
         jsr     pop_int_fp0             ; ss
-        sta     C                       ; C = seconds
+        pha
         jsr     pop_int_fp0             ; mm
-        sta     D                       ; D = minutes
+        pha
         jsr     pop_int_fp0             ; hh
         sta     E                       ; E = hours
         lda     HW_PRESENT
         and     #HW_RTC
         bne     :+
+        pla                             ; Unwind mm and ss before bailing out
+        pla
         jmp     ex_no_device
-:       lda     E                       ; A = hours
-        ldx     D                       ; X = minutes
-        ldy     C                       ; Y = seconds
+:       pla
+        tax                             ; X = minutes
+        pla
+        tay                             ; Y = seconds
+        lda     E                       ; A = hours
         jmp     RtcWriteTime
 
+; Four values, and only D and E survive a pop -- see exec_settime above.
 exec_setdate:
         jsr     evaluate_argument_list
         jsr     pop_int_fp0             ; dd
-        sta     B                       ; B = day
+        pha
         jsr     pop_int_fp0             ; mm
-        sta     C                       ; C = month
+        pha
         jsr     pop_int_fp0             ; yy
-        sta     D                       ; D = year
+        sta     E                       ; E = year
         jsr     pop_int_fp0             ; cc
         sta     RTC_BUF_CENT
         lda     HW_PRESENT
         and     #HW_RTC
         bne     :+
+        pla                             ; Unwind mm and dd before bailing out
+        pla
         jmp     ex_no_device
-:       lda     B                       ; A = day
-        ldx     C                       ; X = month
-        ldy     D                       ; Y = year
+:       pla
+        tax                             ; X = month
+        pla                             ; A = day
+        ldy     E                       ; Y = year
         jmp     RtcWriteDate
 
 ; ---------------------------------------------------------------------------
@@ -487,15 +500,27 @@ ex_sys_call:
 ; Functions
 ; ---------------------------------------------------------------------------
 
-; JOY(n) -- return joystick bitmask for port n (1 or 2); 0 if GPIO absent.
+; JOY(n) -- return the joystick bitmask for port n (1 or 2).
+; Both ports are active low -- pulled high through 1K, grounded by the stick's
+; switches -- so a held button reads 0 and an untouched stick reads $FF.  That
+; makes $FF, not 0, the honest answer for a port that is not fitted at all;
+; 0 would claim every direction and button is held.  Matches FnJoy in the
+; BIOS's own BASIC, down to raising an error for a port that does not exist.
 fun_joy:
-        sta     D                       ; save port number
+        cpx     #0                      ; High byte must be zero...
+        bne     @range
+        cmp     #1                      ; ...and the port must be 1 or 2
+        beq     @port
+        cmp     #2
+        bne     @range
+@port:
+        sta     D                       ; Save the port number
         lda     HW_PRESENT
         and     #HW_GPIO
-        beq     @none
+        beq     @absent
         lda     D
         cmp     #2
-        bcs     @p2                     ; n >= 2 -> port 2
+        beq     @p2
         jsr     ReadJoystick1
         ldx     #0
         rts
@@ -503,15 +528,19 @@ fun_joy:
         jsr     ReadJoystick2
         ldx     #0
         rts
-@none:
-        lda     #0
-        tax
+@absent:
+        lda     #$FF                    ; What an untouched stick reads
+        ldx     #0
         rts
+@range:
+        raise   ERR_OUT_OF_RANGE
 
 ; INKEY(x) -- return ASCII code of a pending key, or 0 if none.
 ; The argument is ignored (vc83 functions require at least one arg).
+; get_key rather than the Kernal's Chrin, which would echo the key to the
+; screen on its way back.
 fun_inkey:
-        jsr     Chrin                   ; C=1 if char available
+        jsr     get_key                 ; C=1 if a key was waiting
         bcs     @got
         lda     #0
 @got:

--- a/targets/ac6502/ac6502_io.s
+++ b/targets/ac6502/ac6502_io.s
@@ -1,55 +1,154 @@
 ; SPDX-FileCopyrightText: 2022-2026 Willis Blackburn / 2026 A.C. Wright
 ;
 ; SPDX-License-Identifier: MIT
+;
+; ac6502 console I/O.
+;
+; The Kernal's Chrin ($A003) echoes every byte it hands back -- it is the
+; BIOS's line-input primitive, not a raw poll.  That is wrong for a break
+; check (the key lands in the middle of a running program's output) and wrong
+; for INKEY (the key appears on screen), and in both cases the byte is
+; swallowed, so a later INPUT never sees it.  So this target reads the input
+; ring buffer directly and decides for itself when to echo.
+;
+; See https://github.com/acwright/6502 for more info
+
+.code
+
+; ---------------------------------------------------------------------------
+; Keyboard input primitives
+; ---------------------------------------------------------------------------
+
+; get_key -- take the next byte out of the BIOS input buffer, without echo.
+; Out: C=1 and A = the byte if one was waiting, C=0 otherwise.
+; X and Y are preserved.
+
+get_key:
+        phx
+        jsr     BufferSize              ; A = unread bytes
+        beq     @none
+        jsr     ReadBuffer              ; A = the byte (clobbers X)
+        pha
+        ; Chrin also releases RTS once the buffer has drained.  Irq asserts it
+        ; when the buffer passes $F0 and nothing else ever lets go again, so a
+        ; serial console would accept one bufferful and then wedge for good if
+        ; this were left out.
+        lda     HW_PRESENT
+        and     #HW_SC
+        beq     @done                   ; No serial card -- nothing to release
+        jsr     BufferSize
+        cmp     #$B0
+        bcs     @done                   ; Still nearly full -- keep RTS asserted
+        lda     #SC_CMD_RX_READY
+        sta     SC_CMD
+@done:
+        pla
+        plx
+        sec
+        rts
+@none:
+        plx
+        clc
+        rts
+
+; peek_key -- look at the next byte without removing it, so anything that is
+; not a break key stays in the buffer for INPUT / INKEY.
+; Out: C=1 and A = the byte if one is waiting, C=0 otherwise.
+; X and Y are preserved.
+
+peek_key:
+        phx
+        jsr     BufferSize
+        beq     @none
+        ldx     READ_PTR                ; Irq only ever advances WRITE_PTR, so a
+        lda     INPUT_BUFFER,x          ;   non-zero count means this byte is ours
+        plx
+        sec
+        rts
+@none:
+        plx
+        clc
+        rts
+
+; check_break -- raise ERR_STOPPED if ESC or CTRL-C is waiting.  Any other key
+; is left in the buffer.  X and Y are preserved; A is clobbered.
+
+check_break:
+        jsr     peek_key
+        bcc     @done
+        cmp     #CH_ESC
+        beq     @break
+        cmp     #CH_CTRLC
+        bne     @done                   ; Not a break key -- leave it for INPUT
+@break:
+        jsr     get_key                 ; Consume the break key itself
+        raise   ERR_STOPPED
+@done:
+        rts
+
+; ---------------------------------------------------------------------------
+; Line input
+; ---------------------------------------------------------------------------
+
+; readline -- collect a line into `buffer`, echoing as it is typed.
+; Returns the length in A; the line is null-terminated.
 
 readline:
         ldy     #0
 @waitchar:
-        jsr     CHRIN
+        jsr     get_key
         bcc     @waitchar
-        ; Check for break keys (ESC or CTRL-C) to interrupt a running program
-        cmp     #CH_ESC
+        cmp     #CH_CR                  ; End of line
+        beq     @done
+        cmp     #CH_ESC                 ; Break keys interrupt a running program
         beq     @check_break
         cmp     #CH_CTRLC
         beq     @check_break
-        ; Check for backspace
         cmp     #CH_BKSP
         beq     @backspace
-        ; Check for CR (end of line)
-        cmp     #CH_CR
-        beq     @done
-        ; Skip other non-printable control characters (LF, NUL, etc.)
+        cmp     #CH_DEL
+        beq     @backspace
         cmp     #CH_SPACE
-        bcc     @waitchar
-        ; Skip DEL ($7F)
-        cmp     #$7F
-        beq     @waitchar
-        ; Ignore if buffer full
-        cpy     #BAS_LINBUF_SIZE
-        bcs     @waitchar
-        ; Store character
+        bcc     @waitchar               ; Other control codes: discard
+        cmp     #CH_DEL
+        bcs     @waitchar               ; $80 and up: not printable here
+        cpy     #MAX_LINE_LENGTH
+        bcs     @waitchar               ; Line full: discard, and do not echo it
         sta     buffer,y
         iny
+        jsr     putch_raw               ; Echo the character we kept
         jmp     @waitchar
 
 @check_break:
         lda     program_state           ; Only break when a program is running
         bne     @waitchar               ; PS_READY (non-zero): discard and keep waiting
-        lda     #ERR_STOPPED
-        jmp     on_raise
+        raise   ERR_STOPPED
 
 @backspace:
         cpy     #0
         beq     @waitchar               ; Nothing to delete
         dey
+        lda     #CH_BKSP                ; BS, space, BS.  The BIOS's video Chrout
+        jsr     putch_raw               ;   erases on BS by itself, but a serial
+        lda     #CH_SPACE               ;   terminal only moves the cursor, so
+        jsr     putch_raw               ;   spell the erase out and satisfy both.
+        lda     #CH_BKSP
+        jsr     putch_raw
         jmp     @waitchar
 
 @done:
         lda     #0
         sta     buffer,y                ; Null-terminate
+        lda     #CH_CR                  ; Echo the newline: we never echoed the CR
+        jsr     putch_raw
         lda     #CH_LF
-        jsr     putch                   ; Echo newline (Chrin echoed the CR)
+        jsr     putch_raw
+        tya                             ; Return the line length
         rts
+
+; ---------------------------------------------------------------------------
+; Output
+; ---------------------------------------------------------------------------
 
 write:
         stax    BC
@@ -66,26 +165,24 @@ write:
 @done:
         rts
 
-; putch -- output one character, but first poll for ESC or CTRL-C so the
-; user can break out of a running BASIC program.  The check is skipped when
-; the program is not running (PS_READY) to avoid eating characters typed at
-; the READY prompt before readline is called.
+; putch -- output one character, polling for a break first so the user can
+; stop a running BASIC program.  The poll only peeks, so a key that is not ESC
+; or CTRL-C stays in the buffer for INPUT / INKEY rather than being eaten and
+; echoed into the middle of the program's output.  Skipped entirely when no
+; program is running, so it costs nothing at the READY prompt.
+
 putch:
-        pha                             ; Save character to output
-        lda     program_state           ; Only poll keyboard while a program is running
-        bne     @output                 ; PS_READY (non-zero): skip break check
-        jsr     Chrin                   ; Non-blocking poll (C=1 if char available)
-        bcc     @output                 ; Nothing in the buffer
-        cmp     #CH_ESC
-        beq     @break
-        cmp     #CH_CTRLC
-        bne     @output                 ; Not a break key; discard and continue
-@break:
-        pla                             ; Discard the saved character
-        lda     #ERR_STOPPED
-        jmp     on_raise
+        pha                             ; Save the character to output
+        lda     program_state
+        bne     @output                 ; PS_READY (non-zero): nothing to break
+        jsr     check_break             ; Does not return if a break key is waiting
 @output:
-        pla                             ; Restore character
+        pla                             ; Restore the character
+
+; putch_raw -- output one character with no break check, for echo and for
+; anything else that has already decided about breaking.
+
+putch_raw:
         jmp     CHROUT
 
 newline:
@@ -95,4 +192,3 @@ newline:
         jmp     putch
 
 .code
-        

--- a/targets/ac6502/ac6502_startup.s
+++ b/targets/ac6502/ac6502_startup.s
@@ -6,7 +6,10 @@
 ; and owns the CPU vectors at $FFFA-$FFFF.  On RESET the CPU jumps to
 ; `startup`, which performs BIOS hardware initialization via KernalInit
 ; and then transfers control to the BASIC interpreter.
-; 
+;
+; This is the BIOS README's "Pattern B" (KernalInit + beep), with the
+; cartridge taking over the BRK vector -- see brk_handler below.
+;
 ; See https://github.com/acwright/6502 for more info
 
 .export startup
@@ -21,10 +24,58 @@ startup:
         jsr     KernalInit              ; Probe & initialize all BIOS hardware.
                                         ; Sets IRQ/BRK/NMI RAM vectors and IO_MODE.
                                         ; Leaves interrupts disabled; caller must CLI.
+
+        ; KernalInit points BRK_PTR at the BIOS handler, which ends in a jump
+        ; to the Monitor at $EE00 -- an address this cartridge has overlaid
+        ; with its own code.  Take the vector over before anything can BRK.
+        lda     #<brk_handler
+        sta     BRK_PTR
+        lda     #>brk_handler
+        sta     BRK_PTR + 1
+
         jsr     Beep                    ; Play the startup beep
         cli                             ; Enable interrupts (keyboard, serial RX)
+
+        ; Clear the screen.  Neither KernalInit nor InitVideo touches the name
+        ; table -- InitVideo only writes the mode registers and reloads the
+        ; character set -- so without this a reset leaves the previous
+        ; session's text on screen underneath the banner.  VideoClear tests
+        ; HW_PRESENT itself and returns immediately on a machine with no video
+        ; card, so this is safe on a serial-only console.
+        jsr     VideoClear
+
+        ; BSS is not zeroed on bare metal, and `write` -> `putch` polls for a
+        ; break whenever program_state says a program is running.  Settle it
+        ; before the banner, which runs ahead of initialize_program.
+        lda     #PS_READY
+        sta     program_state
+
         jsr     display_startup_banner  ; Display the BASIC banner
         jmp     main                    ; Enter the BASIC REPL (never returns)
+
+; BRK handler -- reached from the Kernal's IRQ dispatcher via BRK_PTR, with
+; A/X/Y already restored and the CPU's pushed P/PCL/PCH still on the stack.
+; Reports where it happened and drops back to the READY prompt rather than
+; wedging the machine.  Raising ERR_STOPPED (rather than jumping straight to
+; the prompt) is what restores the interpreter's expression stack.
+
+brk_handler:
+        pla                             ; Discard the pushed P
+        pla                             ; PCL -- as with the BIOS Monitor, the
+        sta     D                       ;   reported address is the BRK + 2
+        pla                             ; PCH
+        sta     E
+        ldax    #brk_message
+        jsr     ex_print_cstr
+        lda     E                       ; Address, high byte first
+        jsr     ex_print_2h
+        lda     D
+        jsr     ex_print_2h
+        jsr     newline
+        raise   ERR_STOPPED
+
+brk_message:
+        .byte   "BRK AT $", 0
 
 ; IRQ / NMI trampolines -- dispatch through the RAM vectors that
 ; KernalInit configured so the BIOS's own handlers stay in charge.


### PR DESCRIPTION
Brings the `ac6502` target up to date with the current [6502-BIOS](https://github.com/acwright/6502-BIOS) (v1.5) and fixes a set of bugs found while auditing it against the BIOS, the [6502-CRT](https://github.com/acwright/6502-CRT) cartridge template, and the [6502 emulator](https://github.com/acwright/6502-EMULATOR).

All changes are confined to `targets/ac6502/`. Nothing in `src/` or the `Makefile` is touched.

## The reported symptom: no screen clear on reset

`ac6502_startup.s` never called `VideoClear` ($A018), so a reset left the previous session's text on screen underneath the banner.

Nothing else does it for you: `KernalInit` initialises hardware, and `InitVideo` writes the eight VDP mode registers and reloads the character set into the pattern table, but neither touches the name table at VRAM $0000. Both other entry points into this BIOS clear explicitly — the BIOS's own boot path (`@BootBASIC: jsr VideoClear / jmp BasEntry`) and the cartridge template (`Cart.asm`) — as does the `apple2` target here, via `jsr HOME`.

Fixed by calling `VideoClear` after `cli`. It tests `HW_PRESENT` itself, so it is a no-op on a serial-only machine.

## Other fixes

**A `BRK` used to kill the interpreter.** `KernalInit` points `BRK_PTR` at the BIOS handler, which ends in a jump to the Monitor at $EE00 — an address the cartridge has overlaid with its own code. Since this target exposes `POKE` and `SYS`, a typo could reach it. The cartridge now takes over `BRK_PTR` after `KernalInit`, reports `BRK AT $xxxx` and raises `ERR_STOPPED` (which is what restores the expression stack) instead of wedging.

**Keystrokes were echoed into program output and swallowed.** The Kernal's `Chrin` ($A003) echoes every byte it returns — it is the BIOS's line-input primitive, not a raw poll. `putch` called it on every character of output to poll for a break, so a key typed during a running program was echoed into the middle of that program's output *and* consumed, leaving nothing for a later `INPUT`/`INKEY`. `INKEY()` had the same problem: it printed the key it read.

Replaced with `get_key` (reads the ring buffer, no echo) and `peek_key` (looks without removing). The break poll now peeks, so a key that is not ESC or CTRL-C stays in the buffer. `get_key` also replicates `Chrin`'s RTS release — `Irq` asserts RTS when the buffer passes $F0 and nothing else ever lets go, so a serial console would otherwise accept one bufferful and wedge for good.

**`SETTIME` and `SETDATE` returned wrong values.** `pop_int_fp0` is documented DE SAFE but not BC SAFE; both routines parked values in `B`/`C` across later pops. `SETDATE 20,26,8,7` produced `2026-11-00` and `SETTIME 13,45,30` produced `13:45:11`. Surplus values now go on the CPU stack, as `exec_sound` already did. (`BasCmdColor` in the BIOS's own BASIC carries the same warning in a comment.)

**`JOY()` reported the wrong value for an absent card.** It returned 0, but the ports are active low, so 0 claims every direction and button is held at once. Now returns `$FF` — what an untouched stick reads — and raises `RANGE` for a port other than 1 or 2, matching `FnJoy` in the BIOS's BASIC.

**`LOCATE` was unbounded.** `VideoSetCursor` computes `row * 40 + col` with no limit of its own, so a row past 51 put the cursor beyond the 960-byte name table and let the next `PRINT` scribble over the character set in the pattern table at VRAM $0800. Now range-checked to 0–23 / 0–39, as the BIOS's BASIC does.

**Backspace did not erase on a serial console.** It only decremented the buffer index. The BIOS's video `Chrout` erases on BS by itself, but a serial terminal only moves the cursor, so the target now emits BS/space/BS and satisfies both. `readline` also handles DEL, echoes explicitly, and uses the core's `MAX_LINE_LENGTH` instead of a target-local `BAS_LINBUF_SIZE` that shadowed it at the same value.

Also seeds `program_state` before the banner — BSS is not zeroed on bare metal, and `write` → `putch` reads it before `initialize_program` runs.

## API surface

`ac6502.inc` was a BIOS v1.0-era snapshot. Added the entries introduced since: `FsLoadFileAddr`–`FsPrintDisk` ($A07E–$A08D), `PrintStr`/`PrintCRLF`/`PrintDecU16` ($A090–$A096), `KBDisable`/`KBEnable` ($A099–$A09C), plus `READ_PTR`, `INPUT_BUFFER` and `SC_CMD`.

`.setcpu "65C02"` moved from `ac6502_extension.s` into `ac6502.inc` so the whole target can use the 65C02 additions. `basic.s` and `main.s` are included ahead of it and remain plain 6502.

## Verification

Built and exercised in the emulator on three machine configurations — all cards, serial-only (`--console serial`), and video-only (`--empty serial`, driven through the VIA keyboard):

- screen clears on both cold and warm reset
- `INKEY` no longer echoes; a key typed during program output is neither echoed nor swallowed
- ESC/CTRL-C break still interrupts a running program
- `POKE 4096,0 : SYS 4096` reports `BRK AT $1002` / `STOPPED`, and the interpreter survives
- `SETTIME 13,45,30` → `13:45:30`; `SETDATE 20,26,8,7` → `2026-08-07`
- `JOY(1)` → `255` with no GPIO card; `JOY(3)` → `RANGE`
- `LOCATE 60,0` and `LOCATE 0,99` → `RANGE`; in-range values position correctly
- destructive backspace on both consoles
- `MEM`, `CLS`, `COLOR`, `BANK`, `VOL`, `SOUND`, `PAUSE`, `NVRAM` all behave

This branch is the ac6502 commit cherry-picked onto current `master`, and was re-built and re-tested there after the lexer rewrite.

## Not included

CF `LOAD`/`SAVE`. The jump-table entries are now in place for it (`FsLoadFileAddr`/`FsSaveFileAddr`/`FsSetDisk`), but it is a feature addition rather than a compatibility fix, needs string-argument handling and a program-image format decision, and no target currently implements it. Happy to follow up separately if it is wanted.
